### PR TITLE
Fix runtime issues for VS2017 build.

### DIFF
--- a/Source/ses_io/src/internals/_output_file.c
+++ b/Source/ses_io/src/internals/_output_file.c
@@ -640,7 +640,7 @@ struct _ses_output_file*  _read_into_output_file(ses_file_handle the_handle) {
   /*  open the file for reading */
 
   if (pFILE == (FILE*)NULL) {
-    pFILE = fopen(filename, "r");  /*  Note file not exist returns 0 */
+    pFILE = fopen(filename, "rb");  /*  Note file not exist returns 0 */
     if (pFILE == (FILE*)NULL) {
 
       /*  destroy constructed output file on error */

--- a/Source/ses_io/src/internals/_ses_file_handle.c
+++ b/Source/ses_io/src/internals/_ses_file_handle.c
@@ -505,7 +505,7 @@ FILE* _getPFILE(struct _ses_file_handle* the_handle) {
 	  switch(the_handle->_the_open_mode) {
 		  case 'R':
   
-		  	pFILE = fopen(filename, "r");  /*  Note file not exist returns 0 */
+		  	pFILE = fopen(filename, "rb");  /*  Note file not exist returns 0 */
    		  	break;
   
   		  case 'A':

--- a/Source/ses_io/src/internals/_ses_standard.c
+++ b/Source/ses_io/src/internals/_ses_standard.c
@@ -1137,7 +1137,7 @@ ses_boolean _read_and_define_tables_from_file(void) {
   ses_boolean return_value = SES_FALSE;
 
   char* filename = "table_defs.sesio";
-  FILE* cfh = fopen(filename, "r");  //  Note file not exist returns 0
+  FILE* cfh = fopen(filename, "rb");  //  Note file not exist returns 0
   if (cfh == NULL) {
   }
   else {

--- a/Source/ses_io/src/internals/binary/_file_list_binary.c
+++ b/Source/ses_io/src/internals/binary/_file_list_binary.c
@@ -1,18 +1,20 @@
 
 
 #include "ses_defines.h"
-#include "ses_globals.h"
 #include "ses_externs.h"
+#include "ses_globals.h"
 #include "ses_internals.h"
 
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
 
 #include "_file_list_binary.h"
 
+//#define DEBUG_READ_LONG_PFILE_BINARY 1
 #undef DEBUG_READ_LONG_PFILE_BINARY
 
-double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses_boolean do_validation) {
+double _read_double_binary(struct _ses_file_handle *pSFH, unsigned int nsig,
+                           ses_boolean do_validation) {
 
   /*  read a long from the current file handle */
   /*  the current code reads little endian files */
@@ -20,7 +22,8 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
   /*  function prototypes */
 
   double my_flip_bytes(double the_double);
-  double my_truncate_for_significant_digits(double the_double, unsigned intnsig);
+  double my_truncate_for_significant_digits(double the_double,
+                                            unsigned intnsig);
   ses_boolean my_do_validation_double(double the_double);
 
   /*  end function prototypes */
@@ -30,19 +33,19 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
   /********************************************************************/
   /*  error check the arguments */
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
-    printf("_read_double_binary: Null ses file handle passed to _read_double\n");
+    printf(
+        "_read_double_binary: Null ses file handle passed to _read_double\n");
 #endif
     _set_latest_error(SES_NULL_OBJECT_ERROR);
     return return_value;
   }
 
-
   /*  internal error checking */
 
-  FILE* pFILE = _getPFILE(pSFH);
-  if (pFILE == (FILE*)NULL) {
+  FILE *pFILE = _getPFILE(pSFH);
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_read_double_binary: Null FILE* in _read_double\n");
 #endif
@@ -56,14 +59,11 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
     printf("_read_double_binary: nsig < 0, error -- changing nsig to 0\n");
 #endif
     nsig = 0;
-    
   }
   /********************************************************************/
-  
 
   /*  set the byte flipping flag */
 
-  
   ses_boolean needs_flip = SES_FALSE;
   if (pSFH->_needs_flip == SES_TRUE) {
     needs_flip = SES_TRUE;
@@ -76,14 +76,19 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
   } myBuffer;
 
   int number_read = fread(&myBuffer.cbuffer[0], 8, 1, pFILE);
+  if (ferror(pFILE))
+    printf("Read error: __FILE__ (__LINE__)");
+  if (feof(pFILE))
+    printf("End-of-File error:  __FILE__ (__LINE__)");
   if (number_read <= 0) {
 #ifdef DEBUG_PRINT
-    printf("_read_double_binary: Failure in reading double from pFILE at location %ld\n", ftell(pFILE));
+    printf("_read_double_binary: Failure in reading double from pFILE at "
+           "location %ld\n",
+           ftell(pFILE));
 #endif
     _set_latest_error(SES_READ_ERROR);
     return_value = 0.0;
-  }
-  else {
+  } else {
 
     /*  flip the bits */
 
@@ -99,8 +104,7 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
     if (nsig != 0) {
       tmp_double = my_truncate_for_significant_digits(myBuffer.dbuffer, nsig);
       return_value = tmp_double;
-    }
-    else {
+    } else {
       return_value = myBuffer.dbuffer;
     }
 
@@ -109,7 +113,8 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
     if (do_validation == SES_TRUE) {
       if (my_do_validation_double(return_value) == SES_FALSE) {
 #ifdef DEBUG_PRINT
-        printf("_read_double_binary: do validation error on double -- setting error\n");
+        printf("_read_double_binary: do validation error on double -- setting "
+               "error\n");
 #endif
         _set_latest_error(SES_READ_ERROR);
         return_value = 0.0;
@@ -117,22 +122,22 @@ double _read_double_binary(struct _ses_file_handle* pSFH, unsigned int nsig, ses
     }
   }
 
-  //_releasePFILE(pSFH);  
+  //_releasePFILE(pSFH);
 
   return return_value;
-
-
 }
 
-
-ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_double, unsigned int nsig, ses_boolean do_validation) {
+ses_boolean _write_double_binary(struct _ses_file_handle *pSFH,
+                                 double the_double, unsigned int nsig,
+                                 ses_boolean do_validation) {
 
   /*  write aa double to the current file handle */
   /*  the current code writes little endian files */
 
   /*  function prototypes */
 
-  double my_truncate_for_significant_digits(double the_double, unsigned intnsig);
+  double my_truncate_for_significant_digits(double the_double,
+                                            unsigned intnsig);
   ses_boolean my_do_validation_double(double the_double);
 
   /*  end function prototypes */
@@ -142,7 +147,7 @@ ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_doubl
   /********************************************************************/
   /*error check the arguments */
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_write_double_binary:  null ses file handle into _write_double\n");
 #endif
@@ -158,17 +163,15 @@ ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_doubl
 #endif
     nsig = 0;
   }
-  
 
-   ses_boolean need_to_release = SES_FALSE;  
-   FILE* pFILE = pSFH->_c_file_handle;
-   if (pSFH->_c_file_handle == (FILE*)NULL) {
-        pFILE = _getPFILE(pSFH);
-        need_to_release = SES_TRUE;
+  ses_boolean need_to_release = SES_FALSE;
+  FILE *pFILE = pSFH->_c_file_handle;
+  if (pSFH->_c_file_handle == (FILE *)NULL) {
+    pFILE = _getPFILE(pSFH);
+    need_to_release = SES_TRUE;
   }
 
- 
-  if (pFILE == (FILE*)NULL) {
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_write_double_binary: Null FILE* in _write_double\n");
 #endif
@@ -184,18 +187,17 @@ ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_doubl
   } myBuffer;
 
   if (do_validation == SES_TRUE) {
-      if (my_do_validation_double(the_double) == SES_FALSE) {
+    if (my_do_validation_double(the_double) == SES_FALSE) {
 #ifdef DEBUG_PRINT
-        printf("_write_double: do validation error on double -- setting error\n");
+      printf("_write_double: do validation error on double -- setting error\n");
 #endif
-        _set_latest_error(SES_WRITE_ERROR);
-        return_value = SES_FALSE;
-      }
-    
+      _set_latest_error(SES_WRITE_ERROR);
+      return_value = SES_FALSE;
+    }
   }
 
   double the_trunc = 0.0;
-  the_trunc =  my_truncate_for_significant_digits(the_double, nsig);
+  the_trunc = my_truncate_for_significant_digits(the_double, nsig);
 
   myBuffer.cbuffer[0] = 0;
   myBuffer.cbuffer[1] = 0;
@@ -219,7 +221,6 @@ ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_doubl
     myBuffer.dbuffer = my_flip_bytes(myBuffer.dbuffer);
   }
 
-
   int number_written = fwrite(&myBuffer.cbuffer[0], 8, 1, pFILE);
   if (number_written <= 0) {
 #ifdef DEBUG_PRINT
@@ -227,24 +228,17 @@ ses_boolean _write_double_binary(struct _ses_file_handle* pSFH, double the_doubl
 #endif
     _set_latest_error(SES_WRITE_ERROR);
     return_value = SES_FALSE;
-  }
-  else {
+  } else {
     return_value = SES_TRUE;
   }
 
   if (need_to_release == SES_TRUE) {
-	_releasePFILE(pSFH);
+    _releasePFILE(pSFH);
   }
   return return_value;
-
-
 }
 
-
-
-
-
-long _read_long_binary(struct _ses_file_handle* pSFH) {
+long _read_long_binary(struct _ses_file_handle *pSFH) {
 
   /*  read a long as a double from the current file handle */
   /*  the current code reads little endian files */
@@ -257,11 +251,10 @@ long _read_long_binary(struct _ses_file_handle* pSFH) {
 
   long return_value = 0;
 
-
   /********************************************************************/
   /*  error check the arguments */
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_read_long_binary: ses file handle null in _read_long\n");
 #endif
@@ -269,8 +262,8 @@ long _read_long_binary(struct _ses_file_handle* pSFH) {
     return 0;
   }
 
-  FILE* pFILE = pSFH->_c_file_handle;
-  if (pFILE == (FILE*)NULL) {
+  FILE *pFILE = pSFH->_c_file_handle;
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_read_long_binary: Null FILE* in _read_long\n");
 #endif
@@ -287,8 +280,8 @@ long _read_long_binary(struct _ses_file_handle* pSFH) {
     char cbuffer[8];
     double dbuffer;
   } myBuffer;
-
-  if (pFILE == (FILE*)NULL) {
+  
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_read_long_binary: null c file handle into _read_long\n");
 #endif
@@ -297,12 +290,17 @@ long _read_long_binary(struct _ses_file_handle* pSFH) {
   }
 
   int number_read = fread(&myBuffer.cbuffer[0], 8, 1, pFILE);
+  if (ferror(pFILE))
+    printf("Read error: __FILE__ (__LINE__)");
+  if (feof(pFILE))
+    printf("End-of-File error:  __FILE__ (__LINE__)");
+
   if (number_read <= 0) {
 #ifdef DEBUG_PRINT
-    printf("_read_long_binary: Failure in reading long from pFILE\n");
+      printf("_read_long_binary: Failure in reading long from pFILE\n");
 #endif
-    _set_latest_error(SES_READ_ERROR);
-    return_value = 0;
+      _set_latest_error(SES_READ_ERROR);
+      return_value = 0;
   }
   else {
 
@@ -310,20 +308,15 @@ long _read_long_binary(struct _ses_file_handle* pSFH) {
     if (needs_flip == SES_TRUE) {
       tmp = my_flip_bytes(myBuffer.dbuffer);
       return_value = tmp;
-    }
-    else {
+    } else {
       return_value = myBuffer.dbuffer;
     }
   }
 
   return return_value;
-
-
 }
 
-
-
-ses_boolean _write_long_binary(struct _ses_file_handle* pSFH, long the_long) {
+ses_boolean _write_long_binary(struct _ses_file_handle *pSFH, long the_long) {
 
   /*  write a long as a double to the current file handle */
   /*  the current code writes little endian files */
@@ -331,7 +324,7 @@ ses_boolean _write_long_binary(struct _ses_file_handle* pSFH, long the_long) {
   ses_boolean return_value = SES_FALSE;
   /********************************************************************/
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_write_long_binary: null ses file handle into _write_long\n");
 #endif
@@ -339,8 +332,8 @@ ses_boolean _write_long_binary(struct _ses_file_handle* pSFH, long the_long) {
     return SES_FALSE;
   }
 
-  FILE* pFILE = pSFH->_c_file_handle;
-  if (pFILE == (FILE*)NULL) {
+  FILE *pFILE = pSFH->_c_file_handle;
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_write_long_binary: Null FILE* in _write_long\n");
 #endif
@@ -367,7 +360,6 @@ ses_boolean _write_long_binary(struct _ses_file_handle* pSFH, long the_long) {
     myBuffer.dbuffer = my_flip_bytes(myBuffer.dbuffer);
   }
 
-
   int number_written = fwrite(&myBuffer.cbuffer[0], 8, 1, pFILE);
   if (number_written <= 0) {
 #ifdef DEBUG_PRINT
@@ -375,33 +367,30 @@ ses_boolean _write_long_binary(struct _ses_file_handle* pSFH, long the_long) {
 #endif
     _set_latest_error(SES_WRITE_ERROR);
     return_value = SES_FALSE;
-  }
-  else {
+  } else {
     return_value = SES_TRUE;
   }
 
-
   return return_value;
-
-
 }
-long _read_long_pFILE_binary(FILE* pFILE, ses_boolean needs_flip) {
+long _read_long_pFILE_binary(FILE *pFILE, ses_boolean needs_flip) {
 
   /*  read a long as a double from the current file handle */
 
   long return_value = 0;
 
- /********************************************************************/
- /*  error check the arguments */
+  /********************************************************************/
+  /*  error check the arguments */
 
-  if (pFILE == (FILE*)NULL) {
+  if (pFILE == (FILE *)NULL) {
 #ifdef DEBUG_PRINT
-    printf("_read_long_pFILE_binary: null c file handle into _read_long_pFILE\n");
+    printf(
+        "_read_long_pFILE_binary: null c file handle into _read_long_pFILE\n");
 #endif
     _set_latest_error(SES_NULL_OBJECT_ERROR);
     return (long)0;
   }
- /********************************************************************/
+  /********************************************************************/
 
   union buffer {
     char cbuffer[8];
@@ -409,10 +398,14 @@ long _read_long_pFILE_binary(FILE* pFILE, ses_boolean needs_flip) {
   } myBuffer;
 
 #ifdef DEBUG_READ_LONG_PFILE_BINARY
-   printf("reading long pfile binary location is %d\n", ftell(pFILE));
+  printf("reading long pfile binary location is %d\n", ftell(pFILE));
 #endif
 
   int number_read = fread(&myBuffer.cbuffer[0], 8, 1, pFILE);
+  if (ferror(pFILE))
+    printf("Read error: __FILE__ (__LINE__)");
+  if (feof(pFILE))
+    printf("End-of-File error:  __FILE__ (__LINE__)");
 #ifdef DEBUG_READ_LONG_PFILE_BINARY
   printf("_read_long_pFILE_binary:  number_read is %d\n", number_read);
 #endif
@@ -423,44 +416,39 @@ long _read_long_pFILE_binary(FILE* pFILE, ses_boolean needs_flip) {
 #endif
     _set_latest_error(SES_READ_ERROR);
     return_value = (long)0;
-  }
-  else {
-
+  } else {
 
     double tmp = 0.0;
     if (needs_flip == SES_TRUE) {
       tmp = my_flip_bytes(myBuffer.dbuffer);
       return_value = (long)tmp;
-    }
-    else {
+    } else {
       return_value = (long)myBuffer.dbuffer;
     }
 #ifdef DEBUG_READ_LONG_PFILE_BINARY
-  printf("_read_long_pFILE_binary:  myBuffer.dbuffer is %e\n", myBuffer.dbuffer);
-  printf("_read_long_pFILE_binary:  tmp is %e\n", tmp);
-  printf("_read_long_pFILE_binary:  return_value is %ld\n", return_value);	
+    printf("_read_long_pFILE_binary:  myBuffer.dbuffer is %e\n",
+           myBuffer.dbuffer);
+    printf("_read_long_pFILE_binary:  tmp is %e\n", tmp);
+    printf("_read_long_pFILE_binary:  return_value is %ld\n", return_value);
 #endif
-
   }
   return return_value;
-
-
 }
 
-ses_boolean  _write_long_pFILE_binary(FILE* pFILE, ses_boolean needs_flip) {
+ses_boolean _write_long_pFILE_binary(FILE *pFILE, ses_boolean needs_flip) {
   return SES_FALSE;
 }
 
-char _read_char_binary(FILE* pFILE ) {
-	return _read_char(pFILE);
+char _read_char_binary(FILE *pFILE) { return _read_char(pFILE); }
+
+ses_boolean _write_char_binary(FILE *pFILE, char the_char) {
+  return _write_char(pFILE, the_char);
 }
 
-ses_boolean _write_char_binary(FILE* pFILE, char the_char) {
-	return _write_char(pFILE, the_char);
-}
-
-ses_word_reference _read_ses_word_array_binary(struct _ses_file_handle* pSFH, long size_array, unsigned int nsig, ses_boolean do_validation) {
-
+ses_word_reference _read_ses_word_array_binary(struct _ses_file_handle *pSFH,
+                                               long size_array,
+                                               unsigned int nsig,
+                                               ses_boolean do_validation) {
 
   /*  read a ses word array from the current file handle */
 
@@ -469,13 +457,13 @@ ses_word_reference _read_ses_word_array_binary(struct _ses_file_handle* pSFH, lo
   /********************************************************************/
   /*  error check the arguments */
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
-    printf("_read_ses_word_array: ses file handle null in _read_ses_word_array\n");
+    printf(
+        "_read_ses_word_array: ses file handle null in _read_ses_word_array\n");
 #endif
     return (ses_word_reference)NULL;
   }
-
 
   if (size_array <= 0) {
 #ifdef DEBUG_PRINT
@@ -484,20 +472,18 @@ ses_word_reference _read_ses_word_array_binary(struct _ses_file_handle* pSFH, lo
     _set_latest_error(SES_NULL_OBJECT_ERROR);
     return (ses_word_reference)NULL;
   }
- /********************************************************************/
+  /********************************************************************/
 
   /*  set flipping flag */
-
 
   ses_boolean needs_flip = SES_FALSE;
   if (pSFH->_needs_flip == SES_TRUE) {
     needs_flip = SES_TRUE;
   }
 
-
   /*  allocate the memory for the return */
 
-  return_value = malloc(sizeof(ses_word)*size_array);
+  return_value = malloc(sizeof(ses_word) * size_array);
   if (return_value == (ses_word_reference)NULL) {
 #ifdef DEBUG_PRINT
     printf("_read_ses_word_array: memory allocation error\n");
@@ -506,17 +492,18 @@ ses_word_reference _read_ses_word_array_binary(struct _ses_file_handle* pSFH, lo
     return (ses_word_reference)NULL;
   }
 
-
-  int i=0;
-  for(i=0; i<size_array; i++) {
+  int i = 0;
+  for (i = 0; i < size_array; i++) {
     return_value[i] = _read_double(pSFH, nsig, do_validation);
   }
 
   return return_value;
 }
 
-
-ses_boolean _write_ses_word_array_binary(struct _ses_file_handle* pSFH, ses_word the_array[], long size_array, unsigned int nsig, ses_boolean do_validation) {
+ses_boolean _write_ses_word_array_binary(struct _ses_file_handle *pSFH,
+                                         ses_word the_array[], long size_array,
+                                         unsigned int nsig,
+                                         ses_boolean do_validation) {
 
   /*  write an array of ses_word's to the current file handle */
 
@@ -525,7 +512,7 @@ ses_boolean _write_ses_word_array_binary(struct _ses_file_handle* pSFH, ses_word
   /********************************************************************/
   /*  error check the arguments */
 
-  if (pSFH == (struct _ses_file_handle*)NULL) {
+  if (pSFH == (struct _ses_file_handle *)NULL) {
 #ifdef DEBUG_PRINT
     printf("_write_ses_word_array_binary: null ses file handle\n");
 #endif
@@ -547,7 +534,7 @@ ses_boolean _write_ses_word_array_binary(struct _ses_file_handle* pSFH, ses_word
   long i = 0;
   ses_boolean tmp = SES_TRUE;
 
-  for (i=0; i < size_array; i++) {
+  for (i = 0; i < size_array; i++) {
 
     tmp = _write_double_binary(pSFH, (double)the_array[i], nsig, do_validation);
     if (tmp == SES_FALSE) {
@@ -557,14 +544,12 @@ ses_boolean _write_ses_word_array_binary(struct _ses_file_handle* pSFH, ses_word
       _set_latest_error(SES_WRITE_ERROR);
       return SES_FALSE;
     }
-
   }
 
   return return_value;
 }
 
-ses_boolean        _write_ses_string_binary(struct _ses_file_handle* pSFH, ses_string the_string, long size_array){
+ses_boolean _write_ses_string_binary(struct _ses_file_handle *pSFH,
+                                     ses_string the_string, long size_array) {
   return SES_FALSE;
 }
-
-

--- a/Source/ses_io/src/user_interface/ses_open.c
+++ b/Source/ses_io/src/user_interface/ses_open.c
@@ -182,7 +182,7 @@ ses_file_handle my_construct_file(ses_string filename,
   switch(open_flags) {
   case 'R':
   
-    pFILE = fopen(filename, "r");  //  Note file not exist returns 0 
+    pFILE = fopen(filename, "rb");  //  Note file not exist returns 0 
     break;
   
   case 'A':
@@ -227,7 +227,7 @@ ses_file_handle my_construct_file(ses_string filename,
   getrlimit(RLIMIT_NOFILE, &rlim);
   int process_open_files = rlim.rlim_cur;
 #else
-  int process_open_files = INT_MAX;
+  int process_open_files = 1024;
 #endif
   
   if (pFILE == NULL || _next_empty_file >= process_open_files) {
@@ -356,7 +356,7 @@ ses_file_type my_determine_file_type(ses_string filename, ses_open_type the_flag
 
   return_value = 'Q';
   FILE* pFILE = (FILE*)NULL;
-  pFILE = fopen(filename, "r");  /*  Note file not exist returns 0 */
+  pFILE = fopen(filename, "rb");  /*  Note file not exist returns 0 */
 
 
   if (pFILE == (FILE*)NULL) {

--- a/Source/src/eos_Utils.c
+++ b/Source/src/eos_Utils.c
@@ -489,14 +489,23 @@ EOS_INTEGER eos_getSesameFileNames (EOS_CHAR ***files, EOS_INTEGER *filesL, EOS_
   for (i = 0; i < location_cnt; i++) {
 
     /* if indexFileName will be <= PATH_MAX, then define it and continue */
+#ifdef _MSC_VER    
+    count =
+      strlen (sesameIndexLocations[i]) + strlen ("sesameFilesDir.txt") + 2;
+#else    
     count =
       strlen (sesameIndexLocations[i]) + strlen ("sesameFilesDir.txt") + 1;
+#endif
     if (count > PATH_MAX)
       continue;
     strcpy (indexFilePath, sesameIndexLocations[i]);
     strcpy (indexFileName, sesameIndexLocations[i]);
+/* docs.microsoft.com/en-us.cpp/preprocessor/predefined-macros */
+#ifdef _MSC_VER    
+    strcat (indexFileName, "\\sesameFilesDir.txt");
+#else
     strcat (indexFileName, "/sesameFilesDir.txt");
-
+#endif
     fileExists = _eos_fileExistsAndValid(indexFileName);
 
     if (fileExists)
@@ -878,11 +887,19 @@ EOS_INTEGER _eos_addDefaultFileNames (EOS_CHAR *srchPathName,
 
   for (i = 0; i < EOS_NUMDEFAULTFILENAMES; i++) {
 
+#ifdef _MSC_VER
+    totChars = strlen (srchPathName) + 3 + strlen (defaultSesameFileNames[i]);
+#else
     totChars = strlen (srchPathName) + 2 + strlen (defaultSesameFileNames[i]);
+#endif
     tmp2 = realloc (tmp2, totChars * sizeof (EOS_CHAR));
 
     strcpy (tmp2, srchPathName);
+#ifdef _MSC_VER
+    strcat (tmp2, "\\");
+#else    
     strcat (tmp2, "/");
+#endif
     strcat (tmp2, defaultSesameFileNames[i]);
 
     /* if file named tmp2 exists, is not a directory, is not longer than

--- a/Source/utils/interp_sesame_data.c
+++ b/Source/utils/interp_sesame_data.c
@@ -214,7 +214,7 @@ EOS_INTEGER parseInput (EOS_CHAR *fName, EOS_INTEGER *N, EOS_REAL **x, EOS_REAL 
     }
 
     if (! strstr(fName, ","))
-      fp = fopen(fName, "r");
+      fp = fopen(fName, "rb");
     else
     { /* comma-delimited list */
       int i;


### PR DESCRIPTION
+ When using `fopen` to read binary files, the mode must be `"rb"`).
+ Add extra error checking to `_file_list_binary.c`.
+ In `ses_open.c`, for WIN32 platforms set `process_open_files` to 1024 instead of INT_MAX.
+ In `eos_Utils.c`, add extra ifdef logic for `_MSC_VER` platforms .  The path separator is `\\` instead of `/`.
+ Formatting changes.